### PR TITLE
New CVar's for access levels (ca_gag_immunity_flags, ca_gag_access_flags, ca_gag_access_flags_high) 

### DIFF
--- a/cstrike/addons/amxmodx/configs/plugins/CA_Gag.cfg
+++ b/cstrike/addons/amxmodx/configs/plugins/CA_Gag.cfg
@@ -23,4 +23,27 @@ ca_gag_prefix "[GAG]"
 // Default: "1i, 5i, 10i, 30i, 1h, 1d, 1w, 1m"
 ca_gag_times "1i, 5i, 10i, 30i, 1h, 1d, 1w, 1m"
 
+// User immunity flag
+//  users with this flag can't be gagged
+//  NOTE: `ca_gag_access_flags_high` can gag this users
+// -
+// Default: "a"
+ca_gag_immunity_flags "a"
+
+// Admin flag
+//  users with this flag can gag users with flag `z`, but can't with flag `ca_gag_immunity_flags`
+//  users with this flag can't be gagged by same flags users (immunity)
+//  NOTE: `ca_gag_access_flags_high` can gag this users
+// -
+// Default: "c"
+ca_gag_access_flags "c"
+
+// High admin flag
+//  users with this flag can everyone
+//  users with this flag can't be gagged
+//  NOTE: `ca_gag_access_flags_high` can gag this users
+// -
+// Default: "l"
+ca_gag_access_flags_high "l"
+
 


### PR DESCRIPTION
Close #20 

Implemented new CVar's
```cpp
// User immunity flag
//  users with this flag can't be gagged
//  NOTE: `ca_gag_access_flags_high` can gag this users
// -
// Default: "a"
ca_gag_immunity_flags "a"

// Admin flag
//  users with this flag can gag users with flag `z`, but can't with flag `ca_gag_immunity_flags`
//  users with this flag can't be gagged by same flags users (immunity)
//  NOTE: `ca_gag_access_flags_high` can gag this users
// -
// Default: "c"
ca_gag_access_flags "c"

// High admin flag
//  users with this flag can everyone
//  users with this flag can't be gagged
//  NOTE: `ca_gag_access_flags_high` can gag this users
// -
// Default: "l"
ca_gag_access_flags_high "l"
```
